### PR TITLE
Fix/Product images decompression

### DIFF
--- a/src/main/java/com/kopchak/worldoftoys/controller/AdminPanelController.java
+++ b/src/main/java/com/kopchak/worldoftoys/controller/AdminPanelController.java
@@ -78,7 +78,7 @@ public class AdminPanelController {
             @RequestParam(name = "price-sort", required = false) String priceSortOrder,
             @RequestParam(name = "availability", required = false) String availability
 
-    ) {
+    ) throws ImageDecompressionException {
         var productsPage = productService.getAdminProductsPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder, availability);
         return new ResponseEntity<>(productsPage, HttpStatus.OK);

--- a/src/main/java/com/kopchak/worldoftoys/controller/AdminPanelController.java
+++ b/src/main/java/com/kopchak/worldoftoys/controller/AdminPanelController.java
@@ -20,7 +20,6 @@ import com.kopchak.worldoftoys.exception.exception.category.CategoryNotFoundExce
 import com.kopchak.worldoftoys.exception.exception.category.DuplicateCategoryNameException;
 import com.kopchak.worldoftoys.exception.exception.email.MessageSendingException;
 import com.kopchak.worldoftoys.exception.exception.image.ImageException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
 import com.kopchak.worldoftoys.exception.exception.order.InvalidOrderException;
 import com.kopchak.worldoftoys.exception.exception.order.InvalidOrderStatusException;
 import com.kopchak.worldoftoys.exception.exception.product.DuplicateProductNameException;
@@ -78,7 +77,7 @@ public class AdminPanelController {
             @RequestParam(name = "price-sort", required = false) String priceSortOrder,
             @RequestParam(name = "availability", required = false) String availability
 
-    ) throws ImageDecompressionException {
+    ) {
         var productsPage = productService.getAdminProductsPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder, availability);
         return new ResponseEntity<>(productsPage, HttpStatus.OK);
@@ -104,8 +103,6 @@ public class AdminPanelController {
         try {
             AdminProductDto product = productService.getProductById(productId);
             return new ResponseEntity<>(product, HttpStatus.OK);
-        } catch (ImageDecompressionException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (ProductNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }

--- a/src/main/java/com/kopchak/worldoftoys/controller/ShopController.java
+++ b/src/main/java/com/kopchak/worldoftoys/controller/ShopController.java
@@ -51,7 +51,7 @@ public class ShopController {
             @RequestParam(name = "brand", required = false) List<String> brandCategories,
             @RequestParam(name = "age", required = false) List<String> ageCategories,
             @RequestParam(name = "price-sort", required = false) String priceSortOrder
-    ) {
+    ) throws ImageDecompressionException {
         var productsPage = productService.getFilteredProductsPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder);
         return new ResponseEntity<>(productsPage, HttpStatus.OK);

--- a/src/main/java/com/kopchak/worldoftoys/controller/ShopController.java
+++ b/src/main/java/com/kopchak/worldoftoys/controller/ShopController.java
@@ -4,7 +4,6 @@ import com.kopchak.worldoftoys.dto.error.ResponseStatusExceptionDto;
 import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
 import com.kopchak.worldoftoys.dto.product.category.FilteringCategoriesDto;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
 import com.kopchak.worldoftoys.exception.exception.product.ProductNotFoundException;
 import com.kopchak.worldoftoys.service.CategoryService;
 import com.kopchak.worldoftoys.service.ProductService;
@@ -51,7 +50,7 @@ public class ShopController {
             @RequestParam(name = "brand", required = false) List<String> brandCategories,
             @RequestParam(name = "age", required = false) List<String> ageCategories,
             @RequestParam(name = "price-sort", required = false) String priceSortOrder
-    ) throws ImageDecompressionException {
+    ) {
         var productsPage = productService.getFilteredProductsPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder);
         return new ResponseEntity<>(productsPage, HttpStatus.OK);
@@ -96,8 +95,6 @@ public class ShopController {
         try {
             var productDto = productService.getProductBySlug(productSlug);
             return new ResponseEntity<>(productDto, HttpStatus.OK);
-        } catch (ImageDecompressionException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (ProductNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }

--- a/src/main/java/com/kopchak/worldoftoys/exception/exception/image/ext/ImageDecompressionException.java
+++ b/src/main/java/com/kopchak/worldoftoys/exception/exception/image/ext/ImageDecompressionException.java
@@ -1,9 +1,0 @@
-package com.kopchak.worldoftoys.exception.exception.image.ext;
-
-import com.kopchak.worldoftoys.exception.exception.image.ImageException;
-
-public class ImageDecompressionException extends ImageException {
-    public ImageDecompressionException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/kopchak/worldoftoys/mapper/product/ProductMapper.java
+++ b/src/main/java/com/kopchak/worldoftoys/mapper/product/ProductMapper.java
@@ -4,13 +4,11 @@ import com.kopchak.worldoftoys.domain.product.Product;
 import com.kopchak.worldoftoys.dto.admin.product.AddUpdateProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminFilteredProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductDto;
-import com.kopchak.worldoftoys.dto.admin.product.AdminProductsPageDto;
 import com.kopchak.worldoftoys.dto.image.ImageDto;
 import com.kopchak.worldoftoys.dto.product.FilteredProductDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -35,11 +33,7 @@ public abstract class ProductMapper {
     @Mapping(target = "mainImage", source = "mainImage")
     public abstract FilteredProductDto toFilteredProductDto(Product product, ImageDto mainImage);
 
-    public AdminProductsPageDto toAdminFilteredProductsPageDto(Page<Product> productPage) {
-        return new AdminProductsPageDto(toAdminFilteredProductDtoList(productPage.getContent()),
-                productPage.getTotalElements(), productPage.getTotalPages());
-    }
-
-    protected abstract List<AdminFilteredProductDto> toAdminFilteredProductDtoList(List<Product> products);
-
+    @Mapping(target = "name", source = "product.name")
+    @Mapping(target = "mainImage", source = "mainImage")
+    public abstract AdminFilteredProductDto toAdminFilteredProductDto(Product product, ImageDto mainImage);
 }

--- a/src/main/java/com/kopchak/worldoftoys/mapper/product/ProductMapper.java
+++ b/src/main/java/com/kopchak/worldoftoys/mapper/product/ProductMapper.java
@@ -1,14 +1,13 @@
 package com.kopchak.worldoftoys.mapper.product;
 
+import com.kopchak.worldoftoys.domain.product.Product;
 import com.kopchak.worldoftoys.dto.admin.product.AddUpdateProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminFilteredProductDto;
-import com.kopchak.worldoftoys.dto.admin.product.AdminProductsPageDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductDto;
-import com.kopchak.worldoftoys.dto.product.FilteredProductDto;
-import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
-import com.kopchak.worldoftoys.dto.product.ProductDto;
+import com.kopchak.worldoftoys.dto.admin.product.AdminProductsPageDto;
 import com.kopchak.worldoftoys.dto.image.ImageDto;
-import com.kopchak.worldoftoys.domain.product.Product;
+import com.kopchak.worldoftoys.dto.product.FilteredProductDto;
+import com.kopchak.worldoftoys.dto.product.ProductDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.data.domain.Page;
@@ -32,17 +31,14 @@ public abstract class ProductMapper {
     @Mapping(target = "ageCategories", ignore = true)
     public abstract Product toProduct(AddUpdateProductDto addUpdateProductDto);
 
-    public FilteredProductsPageDto toFilteredProductsPageDto(Page<Product> productPage) {
-        return new FilteredProductsPageDto(toFilteredProductDtoList(productPage.getContent()),
-                productPage.getTotalElements(), productPage.getTotalPages());
-    }
+    @Mapping(target = "name", source = "product.name")
+    @Mapping(target = "mainImage", source = "mainImage")
+    public abstract FilteredProductDto toFilteredProductDto(Product product, ImageDto mainImage);
 
     public AdminProductsPageDto toAdminFilteredProductsPageDto(Page<Product> productPage) {
         return new AdminProductsPageDto(toAdminFilteredProductDtoList(productPage.getContent()),
                 productPage.getTotalElements(), productPage.getTotalPages());
     }
-
-    protected abstract List<FilteredProductDto> toFilteredProductDtoList(List<Product> products);
 
     protected abstract List<AdminFilteredProductDto> toAdminFilteredProductDtoList(List<Product> products);
 

--- a/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
@@ -9,9 +9,11 @@ import com.kopchak.worldoftoys.domain.image.Image;
 import com.kopchak.worldoftoys.domain.product.Product;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 public interface ImageService {
     Image convertMultipartFileToImage(MultipartFile multipartFile, Product product)
             throws InvalidImageFileFormatException, ImageCompressionException, ImageExceedsMaxSizeException;
 
-    ImageDto decompressImage(Image image) throws ImageDecompressionException;
+    Optional<ImageDto> decompressImage(Image image);
 }

--- a/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Optional;
 
 public interface ImageService {
-    Image convertMultipartFileToImage(MultipartFile multipartFile, Product product)
+    Optional<Image> convertMultipartFileToImage(MultipartFile multipartFile, Product product)
             throws InvalidImageFileFormatException, ImageCompressionException, ImageExceedsMaxSizeException;
 
     Optional<ImageDto> decompressImage(Image image);

--- a/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ImageService.java
@@ -1,12 +1,11 @@
 package com.kopchak.worldoftoys.service;
 
-import com.kopchak.worldoftoys.dto.image.ImageDto;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageCompressionException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageExceedsMaxSizeException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.InvalidImageFileFormatException;
 import com.kopchak.worldoftoys.domain.image.Image;
 import com.kopchak.worldoftoys.domain.product.Product;
+import com.kopchak.worldoftoys.dto.image.ImageDto;
+import com.kopchak.worldoftoys.exception.exception.image.ext.ImageCompressionException;
+import com.kopchak.worldoftoys.exception.exception.image.ext.ImageExceedsMaxSizeException;
+import com.kopchak.worldoftoys.exception.exception.image.ext.InvalidImageFileFormatException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;

--- a/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
@@ -7,7 +7,6 @@ import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
 import com.kopchak.worldoftoys.exception.exception.category.CategoryNotFoundException;
 import com.kopchak.worldoftoys.exception.exception.image.ImageException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
 import com.kopchak.worldoftoys.exception.exception.product.DuplicateProductNameException;
 import com.kopchak.worldoftoys.exception.exception.product.ProductNotFoundException;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,16 +18,16 @@ public interface ProductService {
     FilteredProductsPageDto getFilteredProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                                     BigDecimal maxPrice, List<String> originCategories,
                                                     List<String> brandCategories, List<String> ageCategories,
-                                                    String priceSortOrder) throws ImageDecompressionException;
+                                                    String priceSortOrder);
 
-    ProductDto getProductBySlug(String productSlug) throws ProductNotFoundException, ImageDecompressionException;
+    ProductDto getProductBySlug(String productSlug) throws ProductNotFoundException;
 
     AdminProductsPageDto getAdminProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                               BigDecimal maxPrice, List<String> originCategories,
                                               List<String> brandCategories, List<String> ageCategories,
-                                              String priceSortOrder, String availability) throws ImageDecompressionException;
+                                              String priceSortOrder, String availability);
 
-    AdminProductDto getProductById(Integer productId) throws ProductNotFoundException, ImageDecompressionException;
+    AdminProductDto getProductById(Integer productId) throws ProductNotFoundException;
 
     void updateProduct(Integer productId, AddUpdateProductDto addUpdateProductDto, MultipartFile mainImageFile,
                        List<MultipartFile> imageFileList)

--- a/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
@@ -26,7 +26,7 @@ public interface ProductService {
     AdminProductsPageDto getAdminProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                               BigDecimal maxPrice, List<String> originCategories,
                                               List<String> brandCategories, List<String> ageCategories,
-                                              String priceSortOrder, String availability);
+                                              String priceSortOrder, String availability) throws ImageDecompressionException;
 
     AdminProductDto getProductById(Integer productId) throws ProductNotFoundException, ImageDecompressionException;
 

--- a/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/ProductService.java
@@ -19,7 +19,7 @@ public interface ProductService {
     FilteredProductsPageDto getFilteredProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                                     BigDecimal maxPrice, List<String> originCategories,
                                                     List<String> brandCategories, List<String> ageCategories,
-                                                    String priceSortOrder);
+                                                    String priceSortOrder) throws ImageDecompressionException;
 
     ProductDto getProductBySlug(String productSlug) throws ProductNotFoundException, ImageDecompressionException;
 

--- a/src/main/java/com/kopchak/worldoftoys/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/impl/ImageServiceImpl.java
@@ -28,28 +28,29 @@ public class ImageServiceImpl implements ImageService {
     private final static String IMAGE_CONTENT_TYPE_PREFIX = "image/";
 
     @Override
-    public Image convertMultipartFileToImage(MultipartFile multipartFile, Product product)
+    public Optional<Image> convertMultipartFileToImage(MultipartFile multipartFile, Product product)
             throws InvalidImageFileFormatException, ImageCompressionException, ImageExceedsMaxSizeException {
+        if (multipartFile == null) {
+            return Optional.empty();
+        }
         String fileName = multipartFile.getOriginalFilename();
         if (isNonImageFile(multipartFile)) {
-            String errMsg = String.format("The file with name: %s must have an image type", fileName);
-            log.error(errMsg);
-            throw new InvalidImageFileFormatException(errMsg);
+            throw new InvalidImageFileFormatException(
+                    String.format("The file with name: %s must have an image type", fileName));
         }
         byte[] compressedImg = compressImage(multipartFile, fileName);
         if (compressedImg.length > MAX_IMG_COMPRESSION_SIZE) {
-            String errMsg = String.format("The image with name: %s is too large", fileName);
-            log.error(errMsg);
-            throw new ImageExceedsMaxSizeException(errMsg);
+            throw new ImageExceedsMaxSizeException(String.format("The image with name: %s is too large", fileName));
         }
         String generatedName = generateImageName(multipartFile);
-        return Image
+        Image image = Image
                 .builder()
                 .name(generatedName)
                 .type(multipartFile.getContentType())
                 .image(compressedImg)
                 .product(product)
                 .build();
+        return Optional.of(image);
     }
 
     @Override

--- a/src/main/java/com/kopchak/worldoftoys/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/impl/ProductServiceImpl.java
@@ -9,6 +9,7 @@ import com.kopchak.worldoftoys.dto.admin.category.CategoryIdDto;
 import com.kopchak.worldoftoys.dto.admin.product.AddUpdateProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductsPageDto;
+import com.kopchak.worldoftoys.dto.product.FilteredProductDto;
 import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
 import com.kopchak.worldoftoys.dto.image.ImageDto;
@@ -50,10 +51,17 @@ public class ProductServiceImpl implements ProductService {
     public FilteredProductsPageDto getFilteredProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                                            BigDecimal maxPrice, List<String> originCategories,
                                                            List<String> brandCategories, List<String> ageCategories,
-                                                           String priceSortOrder) {
+                                                           String priceSortOrder) throws ImageDecompressionException {
         Page<Product> productPage = getFilteredProductPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder, null);
-        return productMapper.toFilteredProductsPageDto(productPage);
+        List<FilteredProductDto> filteredProductDtoList = new ArrayList<>();
+        for (Product product : productPage.getContent()) {
+            Image mainImage = product.getMainImage();
+            ImageDto mainImageDto = mainImage == null ? null : imageService.decompressImage(mainImage);
+            filteredProductDtoList.add(productMapper.toFilteredProductDto(product, mainImageDto));
+        }
+        return new FilteredProductsPageDto(filteredProductDtoList, productPage.getTotalElements(),
+                productPage.getTotalPages());
     }
 
     @Override

--- a/src/main/java/com/kopchak/worldoftoys/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/kopchak/worldoftoys/service/impl/ProductServiceImpl.java
@@ -7,12 +7,13 @@ import com.kopchak.worldoftoys.domain.product.category.BrandCategory;
 import com.kopchak.worldoftoys.domain.product.category.OriginCategory;
 import com.kopchak.worldoftoys.dto.admin.category.CategoryIdDto;
 import com.kopchak.worldoftoys.dto.admin.product.AddUpdateProductDto;
+import com.kopchak.worldoftoys.dto.admin.product.AdminFilteredProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductDto;
 import com.kopchak.worldoftoys.dto.admin.product.AdminProductsPageDto;
+import com.kopchak.worldoftoys.dto.image.ImageDto;
 import com.kopchak.worldoftoys.dto.product.FilteredProductDto;
 import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
-import com.kopchak.worldoftoys.dto.image.ImageDto;
 import com.kopchak.worldoftoys.exception.exception.category.CategoryNotFoundException;
 import com.kopchak.worldoftoys.exception.exception.image.ImageException;
 import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
@@ -86,10 +87,17 @@ public class ProductServiceImpl implements ProductService {
     public AdminProductsPageDto getAdminProductsPage(int page, int size, String productName, BigDecimal minPrice,
                                                      BigDecimal maxPrice, List<String> originCategories,
                                                      List<String> brandCategories, List<String> ageCategories,
-                                                     String priceSortOrder, String availability) {
+                                                     String priceSortOrder, String availability) throws ImageDecompressionException {
         Page<Product> productPage = getFilteredProductPage(page, size, productName, minPrice, maxPrice,
                 originCategories, brandCategories, ageCategories, priceSortOrder, availability);
-        return productMapper.toAdminFilteredProductsPageDto(productPage);
+        List<AdminFilteredProductDto> adminProductsPageDtoList = new ArrayList<>();
+        for (Product product : productPage.getContent()) {
+            Image mainImage = product.getMainImage();
+            ImageDto mainImageDto = mainImage == null ? null : imageService.decompressImage(mainImage);
+            adminProductsPageDtoList.add(productMapper.toAdminFilteredProductDto(product, mainImageDto));
+        }
+        return new AdminProductsPageDto(adminProductsPageDtoList, productPage.getTotalElements(),
+                productPage.getTotalPages());
     }
 
     @Override

--- a/src/test/java/com/kopchak/worldoftoys/controller/AdminPanelControllerTest.java
+++ b/src/test/java/com/kopchak/worldoftoys/controller/AdminPanelControllerTest.java
@@ -19,7 +19,6 @@ import com.kopchak.worldoftoys.exception.exception.category.CategoryContainsProd
 import com.kopchak.worldoftoys.exception.exception.category.CategoryNotFoundException;
 import com.kopchak.worldoftoys.exception.exception.category.DuplicateCategoryNameException;
 import com.kopchak.worldoftoys.exception.exception.email.MessageSendingException;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
 import com.kopchak.worldoftoys.exception.exception.order.InvalidOrderStatusException;
 import com.kopchak.worldoftoys.exception.exception.product.DuplicateProductNameException;
 import com.kopchak.worldoftoys.exception.exception.product.ProductNotFoundException;
@@ -120,25 +119,6 @@ class AdminPanelControllerTest {
 
         response.andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(adminProductDto)))
-                .andDo(MockMvcResultHandlers.print());
-    }
-
-    @Test
-    public void getProductById_ThrowImageDecompressionException_ReturnsBadRequestStatusAndResponseStatusExceptionDto() throws Exception {
-        String imageName = "image.jpg";
-        String imageDecompressionExceptionMsg =
-                String.format("The image with name: %s cannot be decompressed", imageName);
-        var responseStatusExceptionDto = getResponseStatusExceptionDto(HttpStatus.BAD_REQUEST,
-                imageDecompressionExceptionMsg);
-
-        doThrow(new ImageDecompressionException(imageDecompressionExceptionMsg))
-                .when(productService).getProductById(eq(PRODUCT_ID));
-
-        ResultActions response = mockMvc.perform(get("/api/v1/admin/products/{productId}", PRODUCT_ID)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        response.andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(content().json(objectMapper.writeValueAsString(responseStatusExceptionDto)))
                 .andDo(MockMvcResultHandlers.print());
     }
 

--- a/src/test/java/com/kopchak/worldoftoys/controller/ShopControllerTest.java
+++ b/src/test/java/com/kopchak/worldoftoys/controller/ShopControllerTest.java
@@ -6,7 +6,6 @@ import com.kopchak.worldoftoys.dto.product.FilteredProductsPageDto;
 import com.kopchak.worldoftoys.dto.product.ProductDto;
 import com.kopchak.worldoftoys.dto.product.category.CategoryDto;
 import com.kopchak.worldoftoys.dto.product.category.FilteringCategoriesDto;
-import com.kopchak.worldoftoys.exception.exception.image.ext.ImageDecompressionException;
 import com.kopchak.worldoftoys.exception.exception.product.ProductNotFoundException;
 import com.kopchak.worldoftoys.service.CategoryService;
 import com.kopchak.worldoftoys.service.JwtTokenService;
@@ -151,23 +150,6 @@ class ShopControllerTest {
     }
 
     @Test
-    public void getProductBySlug_ThrowImageDecompressionException_ReturnsBadRequestStatusAndResponseStatusExceptionDto() throws Exception {
-        String imageDecompressionExceptionMsg = "The image with name: %s cannot be decompressed";
-        when(productService.getProductBySlug(eq(PRODUCT_SLUG)))
-                .thenThrow(new ImageDecompressionException(imageDecompressionExceptionMsg));
-
-        ResultActions response = mockMvc.perform(get("/api/v1/products/{productSlug}", PRODUCT_SLUG)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        var responseStatusExceptionDto = getResponseStatusExceptionDto(HttpStatus.BAD_REQUEST,
-                imageDecompressionExceptionMsg);
-
-        response.andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(content().json(objectMapper.writeValueAsString(responseStatusExceptionDto)))
-                .andDo(print());
-    }
-
-    @Test
     public void getProductBySlug_ThrowProductNotFoundException_ReturnsNotFoundStatusAndResponseStatusExceptionDto() throws Exception {
         String productNotFoundExceptionMsg = String.format("The product with slug: %s is not found.", PRODUCT_SLUG);
         when(productService.getProductBySlug(eq(PRODUCT_SLUG)))
@@ -176,18 +158,18 @@ class ShopControllerTest {
         ResultActions response = mockMvc.perform(get("/api/v1/products/{productSlug}", PRODUCT_SLUG)
                 .contentType(MediaType.APPLICATION_JSON));
 
-        var responseStatusExceptionDto = getResponseStatusExceptionDto(HttpStatus.NOT_FOUND, productNotFoundExceptionMsg);
+        var responseStatusExceptionDto = getResponseStatusExceptionDto(productNotFoundExceptionMsg);
 
         response.andExpect(MockMvcResultMatchers.status().isNotFound())
                 .andExpect(content().json(objectMapper.writeValueAsString(responseStatusExceptionDto)))
                 .andDo(print());
     }
 
-    private ResponseStatusExceptionDto getResponseStatusExceptionDto(HttpStatus httpStatus, String msg) {
+    private ResponseStatusExceptionDto getResponseStatusExceptionDto(String msg) {
         return ResponseStatusExceptionDto
                 .builder()
-                .error(httpStatus.name())
-                .status(httpStatus.value())
+                .error(HttpStatus.NOT_FOUND.name())
+                .status(HttpStatus.NOT_FOUND.value())
                 .message(msg)
                 .build();
     }

--- a/src/test/java/com/kopchak/worldoftoys/integration/AdminPanelControllerIntegrationTest.java
+++ b/src/test/java/com/kopchak/worldoftoys/integration/AdminPanelControllerIntegrationTest.java
@@ -73,7 +73,6 @@ public class AdminPanelControllerIntegrationTest {
     private final static String ORDER_ID = "4c980930-16eb-41cd-b998-29d03118d67c";
     private final static String PRODUCT_NAME = "лялька";
     private final static String DUPLICATE_PRODUCT_NAME = "Пупсик Оксанка";
-    private final static String CATEGORY_NAME = "category-name";
     private final static String DUPLICATE_CATEGORY_NAME = "Devilon";
     private final static String DUPLICATE_PRODUCT_NAME_EXCEPTION_MSG =
             String.format("The product with name: %s is already exist", DUPLICATE_PRODUCT_NAME);
@@ -120,7 +119,7 @@ public class AdminPanelControllerIntegrationTest {
                 BigInteger.ONE, true, categoryIdDto, categoryIdDto, List.of(categoryIdDto));
         mainImage = new MockMultipartFile("image", "filename",
                 "image/jpg", "image".getBytes());
-        categoryNameDto = new CategoryNameDto(CATEGORY_NAME);
+        categoryNameDto = new CategoryNameDto("category-name");
         OrderStatus orderStatus = OrderStatus.AWAITING_PAYMENT;
         statusDto = new StatusDto(orderStatus.name(), orderStatus.getStatus());
     }
@@ -134,23 +133,6 @@ public class AdminPanelControllerIntegrationTest {
 
         response.andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(adminProductDto)))
-                .andDo(MockMvcResultHandlers.print());
-    }
-
-    @Test
-    @WithUserDetails("jane.smith@example.com")
-    public void getProductById_ThrowImageDecompressionException_ReturnsBadRequestStatusAndResponseStatusExceptionDto() throws Exception {
-        String imageName = "lyalka-klaymber1.png";
-        String imageDecompressionExceptionMsg =
-                String.format("The image with name: %s cannot be decompressed", imageName);
-        var responseStatusExceptionDto = getResponseStatusExceptionDto(HttpStatus.BAD_REQUEST,
-                imageDecompressionExceptionMsg);
-
-        ResultActions response = mockMvc.perform(get("/api/v1/admin/products/{productId}", 1001)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        response.andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(content().json(objectMapper.writeValueAsString(responseStatusExceptionDto)))
                 .andDo(MockMvcResultHandlers.print());
     }
 

--- a/src/test/java/com/kopchak/worldoftoys/integration/ShopControllerIntegrationTest.java
+++ b/src/test/java/com/kopchak/worldoftoys/integration/ShopControllerIntegrationTest.java
@@ -172,23 +172,6 @@ public class ShopControllerIntegrationTest {
     }
 
     @Test
-    public void getProductBySlug_ThrowImageDecompressionException_ReturnsBadRequestStatusAndResponseStatusExceptionDto() throws Exception {
-        String existentProductSlug = "lyalka-klaymber";
-
-        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
-        var responseStatusExceptionDto = new ResponseStatusExceptionDto(httpStatus.value(), httpStatus.name(),
-                "The image with name: lyalka-klaymber1.png cannot be decompressed");
-
-
-        ResultActions response = mockMvc.perform(get("/api/v1/products/{productSlug}", existentProductSlug)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        response.andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(content().json(objectMapper.writeValueAsString(responseStatusExceptionDto)))
-                .andDo(MockMvcResultHandlers.print());
-    }
-
-    @Test
     public void getProductBySlug_NonExistentProductSlug_ReturnsNotFoundStatusAndResponseStatusExceptionDto() throws Exception {
         String nonExistentProductSlug = "non-existent-product-slug";
         HttpStatus httpStatus = HttpStatus.NOT_FOUND;


### PR DESCRIPTION
This pull request addresses the fix/products-image-decompression branch, focusing on resolving the image decompression issue and refining the exception handling related to image processing. The changes include ensuring that compressed images are decompressed correctly when returning the list of products on a page, and removing ImageDecompressionException so that the user gets access to the products even if some of the product's images cannot be decompressed.